### PR TITLE
Support for v1 style requests

### DIFF
--- a/lib/jetstream.ex
+++ b/lib/jetstream.ex
@@ -4,6 +4,8 @@ defmodule Jetstream do
   """
   import Nats.Utils
 
+  @type reason :: binary | atom
+
   @defaults [
     subjects: [],
     max_age: 0,
@@ -27,12 +29,12 @@ defmodule Jetstream do
   ```
   ## Examples
   ```
-  {:ok, _msg} = create_stream(conn, "foo")
-  {:ok, _msg} = create_stream(conn, "foo", subjects: ["foo.*"])
+  {:ok, _msg} = stream_create(conn, "foo")
+  {:ok, _msg} = stream_create(conn, "foo", subjects: ["foo.*"])
   ```
   """
-  @spec create_stream(Nats.Client.t, binary, Keyword.t) :: {:ok, Nats.Protocol.Msg.t} | {:error, binary}
-  def create_stream(pid, name, opts \\ []) do
+  @spec stream_create(Nats.Client.t, binary, Keyword.t) :: {:ok, map} | {:error, term}
+  def stream_create(pid, name, opts \\ []) do
     {opts, _trash} = default_opts(opts, @defaults)
 
     payload = Keyword.put(opts, :name, name) |> Map.new()
@@ -41,7 +43,7 @@ defmodule Jetstream do
     |> decode_response()
   end
 
-  def update_stream(pid, name, config \\ []) do
+  def stream_update(pid, name, config \\ []) do
     with {:ok, %{payload: %{"config" => old_config}}} <- stream_info(pid, name) do
       new_config = Map.new(config, fn {k, v} -> {to_string(k), v} end)
       config = Map.merge(old_config, new_config)
@@ -50,7 +52,7 @@ defmodule Jetstream do
     end
   end
 
-  def list_streams(pid) do
+  def stream_list(pid) do
     Nats.Client.request(pid, "$JS.API.STREAM.NAMES")
     |> decode_response()
   end
@@ -60,14 +62,20 @@ defmodule Jetstream do
     |> decode_response()
   end
 
-  def delete_stream(pid, name) do
+  def stream_delete(pid, name) do
     Nats.Client.request(pid, "$JS.API.STREAM.DELETE.#{name}")
     |> decode_response()
   end
 
-  def get_message(pid, name, seq) do
+  def stream_msg_get(pid, name, seq) do
     payload = %{seq: seq}
     Nats.Client.request(pid, "$JS.API.STREAM.MSG.GET.#{name}", payload: payload)
+    |> decode_response()
+  end
+
+  def stream_msg_delete(pid, name, seq) do
+    payload = %{seq: seq}
+    Nats.Client.request(pid, "$JS.API.STREAM.MSG.DELETE.#{name}", payload: payload)
     |> decode_response()
   end
 
@@ -81,7 +89,7 @@ defmodule Jetstream do
         {:ok, %{bytes: 0}} -> :ok
         {:ok, %{payload: json}} -> case Jason.decode(json) do
           {:ok, %{"error" => %{"description" => reason}}} -> {:error, reason}
-          {:ok, _payload} -> :ok
+          {:ok, payload} -> {:ok, payload}
           {:error, reason} -> {:error, reason}
         end
         error -> error
@@ -96,7 +104,7 @@ defmodule Jetstream do
     replay_policy: :instant,
     durable: true,
   ]
-  def create_consumer(pid, stream_name, name, opts \\ []) do
+  def consumer_create(pid, stream_name, name, opts \\ []) do
     opts = Keyword.merge(@defaults, opts)
 
     {endpoint, opts} = case Keyword.pop(opts, :durable) do
@@ -117,7 +125,7 @@ defmodule Jetstream do
     |> decode_response()
   end
 
-  def delete_consumer(pid, stream_name, name) do
+  def consumer_delete(pid, stream_name, name) do
     Nats.Client.request(pid, "$JS.API.CONSUMER.DELETE.#{stream_name}.#{name}")
     |> decode_response()
   end
@@ -127,9 +135,39 @@ defmodule Jetstream do
     |> decode_response()
   end
 
-  def list_consumers(pid, stream_name) do
+  def consumer_list(pid, stream_name) do
     Nats.Client.request(pid, "$JS.API.CONSUMER.LIST.#{stream_name}")
     |> decode_response()
+  end
+
+  @defaults [batch: 1, no_wait: false, expires: 5000]
+  def consumer_msg_next(pid, stream_name, consumer_name, opts \\ []) do
+    {expires, opts} = Keyword.merge(@defaults, opts)
+    |> Keyword.get_and_update!(:expires, &{&1, &1 * 1_000_000})
+
+    payload = Map.new(opts) |> Jason.encode!()
+    subject = "$JS.API.CONSUMER.MSG.NEXT.#{stream_name}.#{consumer_name}"
+
+    Nats.Client.request(pid, subject, payload: payload, timeout: expires + 200, v: 1)
+  end
+
+  @spec consumer_msg_ack(Nats.Client.t, Nats.Protocol.Msg.t | binary, atom, Keyword.t) :: {:ok, Nats.Protocol.Msg.t} | {:error, reason}
+  def consumer_msg_ack(client, msg_or_subject, type, opts \\ [])
+
+  def consumer_msg_ack(pid, msg, type, opts) when is_struct(msg) do
+    consumer_msg_ack(pid, msg.reply_to, type, opts)
+  end
+
+  def consumer_msg_ack(pid, subject, type, opts) when is_binary(subject) do
+    payload = case type do
+      :ack -> "+ACK"
+      :nak -> case opts[:delay] do
+        nil -> "-NAK"
+        delay -> "-NAK " <> Jason.encode!(%{delay: delay * 1_000_000})
+      end
+      :term -> "+TERM"
+    end
+    Nats.Client.request(pid, subject, Keyword.put(opts, :payload, payload))
   end
 
   defp decode_response(resp) do

--- a/lib/jetstream/consumer.ex
+++ b/lib/jetstream/consumer.ex
@@ -14,7 +14,7 @@ defmodule Jetstream.Consumer do
   ```
 
   Additional options passed to `use Jetstream.Consumer` will be passed to
-  `Jetstream.create_consumer/4` when the consumer is created on the Jetstream
+  `Jetstream.consumer_create/4` when the consumer is created on the Jetstream
   server. For example:
   ```
   use Jetstream.Consumer,

--- a/lib/jetstream/consumer/creator.ex
+++ b/lib/jetstream/consumer/creator.ex
@@ -14,7 +14,7 @@ defmodule Jetstream.Consumer.Creator do
 
     {:ok, conn} = Nats.Client.start_link(config)
     with {:ok, %{payload: %{"error" => %{"code" => 404}}}} <- get_consumer(conn, config) do
-      {:ok, %{payload: %{"created" => _}}} = Jetstream.create_consumer(conn, config[:stream], config[:consumer], config)
+      {:ok, %{payload: %{"created" => _}}} = Jetstream.consumer_create(conn, config[:stream], config[:consumer], config)
     end
     :ok = GenServer.stop(conn)
   end

--- a/lib/jetstream/push_consumer.ex
+++ b/lib/jetstream/push_consumer.ex
@@ -30,7 +30,7 @@ defmodule Jetstream.PushConsumer do
 
     {:ok, conn} = Nats.Client.start_link(config)
     {:ok, _sid} = Nats.Client.sub(conn, deliver_subject, queue_group: deliver_subject)
-    {:ok, %{payload: info}} = Jetstream.create_consumer(
+    {:ok, %{payload: info}} = Jetstream.consumer_create(
       conn, config[:stream], config[:consumer],
       Keyword.merge(config, [deliver_subject: deliver_subject, deliver_group: deliver_subject])
     )

--- a/lib/jetstream/stream/creator.ex
+++ b/lib/jetstream/stream/creator.ex
@@ -10,10 +10,10 @@ defmodule Jetstream.Stream.Creator do
     conn = config[:module]
     case get_stream(conn, config) do
       {:ok, %{payload: %{"error" => %{"code" => 404}}}} ->
-        {:ok, %{payload: %{"created" => _}}} = Jetstream.create_stream(conn, config[:name], config)
+        {:ok, %{payload: %{"created" => _}}} = Jetstream.stream_update(conn, config[:name], config)
       {:ok, %{payload: %{"created" => _}}} ->
         {:ok, %{payload: %{"type" => "io.nats.jetstream.api.v1.stream_update_response"}}} =
-          Jetstream.update_stream(conn, config[:name], config)
+          Jetstream.stream_update(conn, config[:name], config)
     end
   end
 

--- a/lib/nats/client.ex
+++ b/lib/nats/client.ex
@@ -372,7 +372,7 @@ defmodule Nats.Client do
     {:reply, send_message(message, state), state}
   end
 
-  def handle_call({:request, pub, _timeout, _style}, _from, state) when pub.bytes > state.max_payload do
+  def handle_call({:request, pub, _timeout, _version}, _from, state) when pub.bytes > state.max_payload do
     {:reply, {:error, "Maximum Payload Violation"}, state}
   end
 
@@ -542,14 +542,14 @@ defmodule Nats.Client do
   end
 
   def handle_message(%Protocol.Msg{} = msg, state) do
-    %{requests_v1: requests_v1} = state
+    %{requests_v1: requests_v1, request_inbox: request_inbox} = state
 
     cond do
 
       Map.has_key?(requests_v1, msg.sid) ->
         reply_to_request_v1(msg, state)
 
-      String.starts_with?(msg.subject, state.request_inbox) ->
+      String.starts_with?(msg.subject, request_inbox) ->
         reply_to_request_v2(msg, state)
 
       true ->
@@ -559,6 +559,7 @@ defmodule Nats.Client do
           nil -> Logger.warn("Unexpected #{inspect msg}")
         end
         {:ok, state}
+
     end
 
   end

--- a/lib/nats/client.ex
+++ b/lib/nats/client.ex
@@ -12,7 +12,7 @@ defmodule Nats.Client do
   ```
   """
 
-  @type t :: pid
+  @type t :: GenServer.server
   @type sid :: binary
 
   use Connection

--- a/lib/nats/protocol/msg.ex
+++ b/lib/nats/protocol/msg.ex
@@ -4,7 +4,7 @@ defmodule Nats.Protocol.Msg do
 
   @type t :: %__MODULE__{
     bytes: integer,
-    payload: binary,
+    payload: binary | nil,
     reply_to: binary | nil,
     sid: binary,
     subject: binary


### PR DESCRIPTION
Unfortunately Jetstream's `$JS.API.CONSUMER.MSG.NEXT` API uses Nats' old school style of request/response.

To use the old style, use the `v` option when making requests:
```elixir
Nats.Client.request(client, "$JS.API.CONSUMER.MSG.NEXT.foo.foo", v: 1)
```