### PR TITLE
Telemetry notifications

### DIFF
--- a/lib/nats/protocol/msg.ex
+++ b/lib/nats/protocol/msg.ex
@@ -4,6 +4,7 @@ defmodule Nats.Protocol.Msg do
 
   @type t :: %__MODULE__{
     bytes: integer,
+    headers: [binary] | [],
     payload: binary | nil,
     reply_to: binary | nil,
     sid: binary,

--- a/test/nats/notifications_test.exs
+++ b/test/nats/notifications_test.exs
@@ -39,42 +39,4 @@ defmodule Nats.NotificationsTest do
     send(pid, {what, meta.client})
   end
 
-  # @tag capture_log: true
-  # test "disconnect on monitor" do
-  #   {:ok, conn} = Nats.Client.start_link()
-  #   :ok = Nats.Client.monitor(conn)
-
-  #   socket = Nats.Client.debug(conn).socket
-  #   send(conn, {:tcp_closed, socket})
-
-  #   assert_receive {:nats_client_disconnect, ^conn}
-  # end
-
-  # test "cleans up monitors (start_link)" do
-  #   pid = spawn(fn -> Process.sleep(10_000) end)
-  #   {:ok, conn} = Nats.Client.start_link(monitor: pid)
-  #   Process.exit(pid, :kill)
-
-  #   monitors = Stream.repeatedly(fn -> Nats.Client.debug(conn).notify end)
-  #   |> Stream.with_index()
-  #   |> Enum.reduce_while(nil, fn
-  #     {_monitors, 10}, acc -> {:halt, acc}
-  #     {[], _}, _acc -> {:halt, []}
-  #     {monitors, _}, _acc ->
-  #       Process.sleep(10)
-  #       {:cont, monitors}
-  #   end)
-
-  #   assert [] == monitors
-  # end
-
-  # test "cleans up monitors (monitor)" do
-  #   {:ok, conn} = Nats.Client.start_link()
-
-  #   Task.async(fn -> Nats.Client.monitor(conn) end)
-  #   |> Task.await()
-
-  #   assert [] == Nats.Client.debug(conn).notify
-  # end
-
 end

--- a/test/nats/notifications_test.exs
+++ b/test/nats/notifications_test.exs
@@ -1,63 +1,80 @@
 defmodule Nats.NotificationsTest do
   use ExUnit.Case
 
-  test "connect on start_link" do
-    {:ok, conn} = Nats.Client.start_link(monitor: true)
-    assert_receive {:nats_client_connect, ^conn}
+  setup do
+    :ok = :telemetry.attach_many(:notification_test,
+      [
+        [:nats, :client, :connect],
+        [:nats, :client, :disconnect]
+      ],
+      &handler/4,
+      self()
+    )
+
+    on_exit fn ->
+      :ok = :telemetry.detach(:notification_test)
+    end
+
+    :ok
   end
 
-  test "connect on monitor" do
+  test "connect" do
     {:ok, conn} = Nats.Client.start_link()
-    :ok = Nats.Client.monitor(conn)
-    assert_receive {:nats_client_connect, ^conn}
+    assert_receive {:connect, ^conn}
   end
 
   @tag capture_log: true
-  test "disconnect on start_link" do
-    {:ok, conn} = Nats.Client.start_link(monitor: true)
+  test "reconnect" do
+    {:ok, conn} = Nats.Client.start_link()
 
     socket = Nats.Client.debug(conn).socket
     send(conn, {:tcp_closed, socket})
 
-    assert_receive {:nats_client_disconnect, ^conn}
+    assert_receive {:connect, ^conn}
+    assert_receive {:disconnect, ^conn}
+    assert_receive {:connect, ^conn}
   end
 
-  @tag capture_log: true
-  test "disconnect on monitor" do
-    {:ok, conn} = Nats.Client.start_link()
-    :ok = Nats.Client.monitor(conn)
-
-    socket = Nats.Client.debug(conn).socket
-    send(conn, {:tcp_closed, socket})
-
-    assert_receive {:nats_client_disconnect, ^conn}
+  def handler([:nats, :client, what], %{}, meta, pid) do
+    send(pid, {what, meta.client})
   end
 
-  test "cleans up monitors (start_link)" do
-    pid = spawn(fn -> Process.sleep(10_000) end)
-    {:ok, conn} = Nats.Client.start_link(monitor: pid)
-    Process.exit(pid, :kill)
+  # @tag capture_log: true
+  # test "disconnect on monitor" do
+  #   {:ok, conn} = Nats.Client.start_link()
+  #   :ok = Nats.Client.monitor(conn)
 
-    monitors = Stream.repeatedly(fn -> Nats.Client.debug(conn).notify end)
-    |> Stream.with_index()
-    |> Enum.reduce_while(nil, fn
-      {_monitors, 10}, acc -> {:halt, acc}
-      {[], _}, _acc -> {:halt, []}
-      {monitors, _}, _acc ->
-        Process.sleep(10)
-        {:cont, monitors}
-    end)
+  #   socket = Nats.Client.debug(conn).socket
+  #   send(conn, {:tcp_closed, socket})
 
-    assert [] == monitors
-  end
+  #   assert_receive {:nats_client_disconnect, ^conn}
+  # end
 
-  test "cleans up monitors (monitor)" do
-    {:ok, conn} = Nats.Client.start_link()
+  # test "cleans up monitors (start_link)" do
+  #   pid = spawn(fn -> Process.sleep(10_000) end)
+  #   {:ok, conn} = Nats.Client.start_link(monitor: pid)
+  #   Process.exit(pid, :kill)
 
-    Task.async(fn -> Nats.Client.monitor(conn) end)
-    |> Task.await()
+  #   monitors = Stream.repeatedly(fn -> Nats.Client.debug(conn).notify end)
+  #   |> Stream.with_index()
+  #   |> Enum.reduce_while(nil, fn
+  #     {_monitors, 10}, acc -> {:halt, acc}
+  #     {[], _}, _acc -> {:halt, []}
+  #     {monitors, _}, _acc ->
+  #       Process.sleep(10)
+  #       {:cont, monitors}
+  #   end)
 
-    assert [] == Nats.Client.debug(conn).notify
-  end
+  #   assert [] == monitors
+  # end
+
+  # test "cleans up monitors (monitor)" do
+  #   {:ok, conn} = Nats.Client.start_link()
+
+  #   Task.async(fn -> Nats.Client.monitor(conn) end)
+  #   |> Task.await()
+
+  #   assert [] == Nats.Client.debug(conn).notify
+  # end
 
 end

--- a/test/nats/resub_test.exs
+++ b/test/nats/resub_test.exs
@@ -1,0 +1,61 @@
+defmodule Nats.ResubTest do
+  use ExUnit.Case
+
+  setup do
+    :ok = :telemetry.attach_many(:notification_test,
+      [
+        [:nats, :client, :connect],
+        [:nats, :client, :disconnect]
+      ],
+      &handler/4,
+      self()
+    )
+
+    on_exit fn ->
+      :ok = :telemetry.detach(:notification_test)
+    end
+
+    :ok
+  end
+
+  @tag capture_log: true
+  test "resubs on disconnect" do
+    {:ok, conn} = Nats.Client.start_link()
+    assert_receive {:connect, ^conn}
+
+    {:ok, _sid} = Nats.Client.sub(conn, "foo")
+
+    # Simulate a disconnect.
+    socket = Nats.Client.debug(conn).socket
+    send(conn, {:tcp_closed, socket})
+    assert_receive {:disconnect, ^conn}
+    assert_receive {:connect, ^conn}
+
+    Nats.Client.pub(conn, "foo", payload: "bar")
+
+    assert_receive %Nats.Protocol.Msg{subject: "foo", payload: "bar"}
+  end
+
+  @tag capture_log: true
+  test "does not resub on disconnect" do
+    {:ok, conn} = Nats.Client.start_link(resub: false)
+    assert_receive {:connect, ^conn}
+
+    {:ok, _sid} = Nats.Client.sub(conn, "foo")
+
+    # Simulate a disconnect.
+    socket = Nats.Client.debug(conn).socket
+    send(conn, {:tcp_closed, socket})
+    assert_receive {:disconnect, ^conn}
+    assert_receive {:connect, ^conn}
+
+    Nats.Client.pub(conn, "foo", payload: "bar")
+
+    refute_receive %Nats.Protocol.Msg{subject: "foo", payload: "bar"}
+  end
+
+  def handler([:nats, :client, what], %{}, meta, pid) do
+    send(pid, {what, meta.client})
+  end
+
+end


### PR DESCRIPTION
This backs out #5 and removes the idea of notify/monitor completely. The use case for that feature was misguided and if you follow the Nats recommendation for doing a batched pull consumer request, then the problem doesn't exist at all.

Essentially, if you want to make a batch request, you should make a new subscription every time and use `UNSUB`. Using this method, it's easy to use an Elixir timer to make a new batch request if a connection reconnects.

There are now telemetry events for connect and disconnect, though I'm not sure why anyone would use them.

You can also now opt out of automatic resubscriptions on reconnect with the `resub: false` option.