### PR TITLE
use Jetstream, minor API changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   nats:
-    image: nats:2.9-alpine
+    image: nats:2.10-alpine
     command:
       - -js
     ports:

--- a/test/jetstream_test.exs
+++ b/test/jetstream_test.exs
@@ -1,5 +1,22 @@
+defmodule Js do
+  use Jetstream, nats: JetstreamClient
+end
+
 defmodule JetstreamTest do
   use ExUnit.Case
+
+  setup_all do
+    {:ok, client} = Nats.Client.start_link(name: JetstreamClient)
+    {:ok, %{client: client}}
+  end
+
+  setup do
+    on_exit(fn ->
+      Js.stream_delete("foo")
+    end)
+
+    :ok
+  end
 
   test "parse_ack" do
     info = Jetstream.parse_ack("$JS.ACK.change-stream.ChangeLogger/Consumer.1.104.2.1660858232357389126.0")
@@ -14,6 +31,66 @@ defmodule JetstreamTest do
       timestamp: ~U[2022-08-18 21:30:32.357389Z],
       pending: 0
     }
+  end
+
+  test "stream api" do
+    {:ok, resp} = Js.stream_list()
+    assert resp.payload["streams"] == nil
+
+    {:error, resp} = Js.stream_info("foo")
+    assert resp.payload["error"]["code"] == 404
+
+    {:ok, _} = Js.stream_create("foo")
+
+    {:ok, resp} = Js.stream_list()
+    assert resp.payload["streams"] == ["foo"]
+
+    {:ok, resp} = Js.stream_info("foo")
+    assert resp.payload["config"]["subjects"] == ["foo"]
+
+    {:ok, _} = Js.stream_update("foo", subjects: ["foo", "bar"])
+
+    {:ok, resp} = Js.stream_info("foo")
+    assert resp.payload["config"]["subjects"] == ["foo", "bar"]
+
+    {:ok, _} = Js.stream_delete("foo")
+
+    {:ok, resp} = Js.stream_list()
+    assert resp.payload["streams"] == nil
+
+    {:error, resp} = Js.stream_info("foo")
+    assert resp.payload["error"]["code"] == 404
+  end
+
+  test "consumer api" do
+    {:ok, _} = Js.stream_create("foo")
+
+    {:ok, resp} = Js.consumer_list("foo")
+    assert resp.payload["consumers"] == []
+
+    {:error, resp} = Js.consumer_info("foo", "bar")
+    assert resp.payload["error"]["code"] == 404
+
+    {:ok, _} = Js.consumer_create("foo", "bar", filter_subjects: ["foo"])
+
+    {:ok, resp} = Js.consumer_list("foo")
+    assert resp.payload["consumers"] != []
+
+    {:ok, resp} = Js.consumer_info("foo", "bar")
+    assert resp.payload["config"]["filter_subjects"] == ["foo"]
+
+    {:ok, _} = Js.consumer_update("foo", "bar", filter_subjects: ["bar", "foo"])
+
+    {:ok, resp} = Js.consumer_info("foo", "bar")
+    assert resp.payload["config"]["filter_subjects"] == ["bar", "foo"]
+
+    {:ok, _} = Js.consumer_delete("foo", "bar")
+
+    {:ok, resp} = Js.consumer_list("foo")
+    assert resp.payload["consumers"] == []
+
+    {:error, resp} = Js.consumer_info("foo", "bar")
+    assert resp.payload["error"]["code"] == 404
   end
 
 end


### PR DESCRIPTION
```elixir
defmodule MyJetstream do
  use Jetstream, nats: MyNatsClient
end
```

All API calls will now return `{:error, Nats.Protocol.Msg.t}` if an error is detected in the payload. Previously you had to match on:
```elixir
case Jetstream.stream_create(pid, "foo") do
  {:error, _reason -> handle_error()
  {:ok, %{payload: %{"error" => _error}} -> handle_error()
end
```